### PR TITLE
implement cluster query features on GeoJsonSource

### DIFF
--- a/lib/src/interop/style/sources/geojson_source_interop.dart
+++ b/lib/src/interop/style/sources/geojson_source_interop.dart
@@ -17,4 +17,13 @@ class GeoJsonSourceJsImpl {
 
   external GeoJsonSourceJsImpl setData(
       FeatureCollectionJsImpl featureCollection);
+
+  external GeoJsonSourceJsImpl getClusterChildren(
+      int clusterId, Function(dynamic, [List<dynamic>?]) callback);
+
+  external GeoJsonSourceJsImpl getClusterLeaves(int clusterId, int limit,
+      int offset, Function(dynamic, [List<dynamic>?]) callback);
+
+  external GeoJsonSourceJsImpl getClusterExpansionZoom(
+      int clusterId, Function(dynamic, [int?]) callback);
 }

--- a/lib/src/style/sources/geojson_source.dart
+++ b/lib/src/style/sources/geojson_source.dart
@@ -1,5 +1,6 @@
 library mapboxgl.style.sources.geojson_source;
 
+import 'package:js/js.dart';
 import 'package:mapbox_gl_dart/mapbox_gl_dart.dart';
 import 'package:mapbox_gl_dart/src/interop/interop.dart';
 
@@ -19,6 +20,45 @@ class GeoJsonSource extends Source<GeoJsonSourceJsImpl> {
 
   GeoJsonSource setData(FeatureCollection featureCollection) =>
       GeoJsonSource.fromJsObject(jsObject.setData(featureCollection.jsObject));
+
+  GeoJsonSource getClusterChildren(
+          int clusterId, Function(dynamic, List<Feature>?) callback) =>
+      GeoJsonSource.fromJsObject(
+        jsObject.getClusterChildren(
+          clusterId,
+          allowInterop((error, [children]) {
+            callback(
+              error,
+              children?.map((child) => Feature.fromJsObject(child)).toList(),
+            );
+          }),
+        ),
+      );
+
+  GeoJsonSource getClusterLeaves(int clusterId, int limit, int offset,
+          Function(dynamic, List<Feature>?) callback) =>
+      GeoJsonSource.fromJsObject(
+        jsObject.getClusterLeaves(
+          clusterId,
+          limit,
+          offset,
+          allowInterop((error, [leaves]) {
+            callback(
+              error,
+              leaves?.map((leaf) => Feature.fromJsObject(leaf)).toList(),
+            );
+          }),
+        ),
+      );
+
+  GeoJsonSource getClusterExpansionZoom(
+          int clusterId, Function(dynamic, int?) callback) =>
+      GeoJsonSource.fromJsObject(
+        jsObject.getClusterExpansionZoom(
+          clusterId,
+          allowInterop((error, [level]) => callback(error, level)),
+        ),
+      );
 
   /// Creates a new GeoJsonSource from a [jsObject].
   GeoJsonSource.fromJsObject(GeoJsonSourceJsImpl jsObject)


### PR DESCRIPTION
Implements [`getClusterChildren`](https://docs.mapbox.com/mapbox-gl-js/api/sources/?q=queryRenderedFeatures&size=n_10_n#geojsonsource#getclusterchildren), [`getClusterLeaves`](https://docs.mapbox.com/mapbox-gl-js/api/sources/?q=queryRenderedFeatures&size=n_10_n#geojsonsource#getclusterleaves), and [`getClusterExpansionZoom`](https://docs.mapbox.com/mapbox-gl-js/api/sources/?q=queryRenderedFeatures&size=n_10_n#geojsonsource#getclusterexpansionzoom) on `GeoJsonSource`.