### PR TITLE
Default values for PositionOptions fields

### DIFF
--- a/lib/src/ui/control/geolocate_control.dart
+++ b/lib/src/ui/control/geolocate_control.dart
@@ -38,9 +38,9 @@ class PositionOptions extends JsObjectWrapper<PositionOptionsJsImpl> {
   num get timeout => jsObject.timeout;
 
   factory PositionOptions({
-    bool? enableHighAccuracy,
-    num? maximumAge,
-    num? timeout,
+    bool? enableHighAccuracy = false,
+    num? maximumAge = 0,
+    num? timeout = double.infinity,
   }) =>
       PositionOptions.fromJsObject(PositionOptionsJsImpl(
         enableHighAccuracy: enableHighAccuracy,


### PR DESCRIPTION
Set default values for `enableHighAccuracy`, `maximumAge` and `timeout`, with respect to https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#syntax